### PR TITLE
Fix issue where ios browsers are scrollable when modal is open

### DIFF
--- a/src/VEasyDialog.vue
+++ b/src/VEasyDialog.vue
@@ -170,6 +170,8 @@ export default {
             )
             document.body.style.overflow =
                 newOpenedDialogs.length > 0 ? 'hidden' : ''
+            document.documentElement.style.overflow =
+                newOpenedDialogs.length > 0 ? 'hidden' : ''
         },
         openedDialogs() {
             return JSON.parse(document.body.dataset.openedDialogs)


### PR DESCRIPTION
FIx for #1 - Set overflow:hidden to <html> tag as well.